### PR TITLE
Import path

### DIFF
--- a/src/cg/cpp/cgcpp.tsc
+++ b/src/cg/cpp/cgcpp.tsc
@@ -25,11 +25,12 @@ import cg::cpp::cppsource
 func ToCppM(#system:TSystem, #module: Module) -> Result
 → let #mainurl = GetSystemURL(#system)
   let #url = GetModuleURL(#module)
+  let #base = GetModuleURLBase(#module)
   let #buildir = GetConfigDef(#system, "build-dir", "")
-  let #types = TargetCppTypes(#mainurl, #url, #buildir)
-  let #sigs = TargetCppSigs(#mainurl, #url, #buildir)
-  let #header = TargetCppHeader(#mainurl, #url, #buildir)
-  let #source = TargetCppSource(#mainurl, #url, #buildir)
+  let #types = TargetCppTypes(#mainurl, #url, #base, #buildir)
+  let #sigs = TargetCppSigs(#mainurl, #url, #base, #buildir)
+  let #header = TargetCppHeader(#mainurl, #url, #base, #buildir)
+  let #source = TargetCppSource(#mainurl, #url, #base, #buildir)
   let #result = CppSaveAllTmp(#system, #module, #types, #sigs, #header, #source)
   let #result1 = CppMoveTmp(#result, #types)
   let #result2 = CppMoveTmp(#result1, #sigs)
@@ -55,31 +56,33 @@ func CppMoveTmp(#result:Result, #filename: String) -> Result
       Debug(ConcatString("delete ", #tmp), ()->#result)
 
 /* Get the absolute name of the target c++ header file containing forward declarations */
-func TargetCppTypes(#mainurl: String, #input: String, #dest: String) -> String
-→ Replace(TargetCppHeader(#mainurl, #input, #dest), ".h", "_types.h")
+func TargetCppTypes(#mainurl: String, #input: String, #base: String, #dest: String) -> String
+→ Replace(TargetCppHeader(#mainurl, #input, #base, #dest), ".h", "_types.h")
 
 /* Get the absolute name of the target c++ header file containing signatures */
-func TargetCppSigs(#mainurl: String, #input: String, #dest: String) -> String
-→ Replace(TargetCppHeader(#mainurl, #input, #dest), ".h", "_sigs.h")
+func TargetCppSigs(#mainurl: String, #input: String, #base: String, #dest: String) -> String
+→ Replace(TargetCppHeader(#mainurl, #input, #base, #dest), ".h", "_sigs.h")
 
 /* Get the absolute name of the target c++ header file */
-@Extern func TargetCppHeader(#mainurl: String, #input: String, #dest: String) -> String
+@Extern func TargetCppHeader(#mainurl: String, #input: String, #base: String, #dest: String) -> String
 
 /* Get the absolute name of the target c++ source file */
-@Extern func TargetCppSource(#mainurl: String, #input: String, #dest: String) -> String
+@Extern func TargetCppSource(#mainurl: String, #input: String, #base: String, #dest: String) -> String
 
 /* Tell whether the generated files needed to be regenerated */
-func CppNeedRegen(#system:TSystem, #url: String) -> Bool
+func CppNeedRegen(#system:TSystem, #url_and_base: URLAndBase) -> Bool
 → let #mainurl = GetSystemURL(#system)
   let #buildir = GetConfigDef(#system, "build-dir", "")
+  let #url = GetURLOfUnB(#url_and_base)
+  let #base = GetBaseOfUnB(#url_and_base)
   let #srcmod = FileLastModified(#url)
-  if GreaterThan(#srcmod, FileLastModified(TargetCppTypes(#mainurl, #url, #buildir)))
+  if GreaterThan(#srcmod, FileLastModified(TargetCppTypes(#mainurl, #url, #base, #buildir)))
     TRUE
-  else if GreaterThan(#srcmod, FileLastModified(TargetCppSigs(#mainurl, #url, #buildir)))
+  else if GreaterThan(#srcmod, FileLastModified(TargetCppSigs(#mainurl, #url, #base, #buildir)))
     TRUE
-  else if GreaterThan(#srcmod, FileLastModified(TargetCppHeader(#mainurl, #url, #buildir)))
+  else if GreaterThan(#srcmod, FileLastModified(TargetCppHeader(#mainurl, #url, #base, #buildir)))
     TRUE
-  else if GreaterThan(#srcmod, FileLastModified(TargetCppSource(#mainurl, #url, #buildir)))
+  else if GreaterThan(#srcmod, FileLastModified(TargetCppSource(#mainurl, #url, #base, #buildir)))
     TRUE
   else
     FALSE

--- a/src/cg/cpp/cgcpp.tsc
+++ b/src/cg/cpp/cgcpp.tsc
@@ -70,11 +70,11 @@ func TargetCppSigs(#mainurl: String, #input: String, #base: String, #dest: Strin
 @Extern func TargetCppSource(#mainurl: String, #input: String, #base: String, #dest: String) -> String
 
 /* Tell whether the generated files needed to be regenerated */
-func CppNeedRegen(#system:TSystem, #url_and_base: URLAndBase) -> Bool
+func CppNeedRegen(#system:TSystem, #module_url: URLAndBase) -> Bool
 → let #mainurl = GetSystemURL(#system)
   let #buildir = GetConfigDef(#system, "build-dir", "")
-  let #url = GetURLOfUnB(#url_and_base)
-  let #base = GetBaseOfUnB(#url_and_base)
+  let #url = GetURLOfUnB(#module_url)
+  let #base = GetBaseOfUnB(#module_url)
   let #srcmod = FileLastModified(#url)
   if GreaterThan(#srcmod, FileLastModified(TargetCppTypes(#mainurl, #url, #base, #buildir)))
     TRUE

--- a/src/cg/cpp/cppcommon.tsc
+++ b/src/cg/cpp/cppcommon.tsc
@@ -178,7 +178,7 @@ return Optional<†⟨ParamFormCppClassName(#sortname, (), CFC_VAR)⟩>::nullopt
 /* Generate static method MakeVariable corresponding to the given `#sortname`. */
 func CppMethodMakeVariable(#sortname: String, #csortvars?:List<Core_csortvars_sort>, #allowvar: Bool, #def: Bool) -> Text4_text_sort
 → text⟦†⟨TextIf(#def, ()->CppTemplatePrefix(#csortvars?))⟩
-†⟨TextIf(Not(#def), ()->text⟦static ⟧)⟩tosca::Variable& †⟨CppQualifier(#sortname, #csortvars?, #def)⟩MakeVariable(tosca::Context ctx, const tosca::string& hint)†⟨
+†⟨TextIf(Not(#def), ()->text⟦static ⟧)⟩tosca::Variable& †⟨CppQualifier(#sortname, #csortvars?, #def)⟩MakeVariable(tosca::Context& ctx, const tosca::string& hint)†⟨
    If(#def,
      ()->If(#allowvar,
        ()->text⟦¶{→

--- a/src/cg/java/cgjava.tsc
+++ b/src/cg/java/cgjava.tsc
@@ -22,13 +22,13 @@ import cg::utils
 
 /* Generates Java code for the given `#module` */
 func ToJavaM(#system: TSystem, #module: Module) -> Result
-→ ToJavaAux(#system, #module, TargetJavaFilename(GetModuleURL(#module), GetConfigDef(#system, "build-dir", ""),
+→ ToJavaAux(#system, #module, TargetJavaFilename(GetModuleURL(#module), GetModuleURLBase(#module), GetConfigDef(#system, "build-dir", ""),
     GetSystemURL(#system), GetConfigDef(#system, "package", "")))
 
 func ToJavaAux(#system: TSystem, #module: Module, #source: String) -> Result
 → SaveResource("text", #source, text⟦
       /** Generated File */
-      †⟨PackageDeclaration(GetModuleURL(#module), GetSystemURL(#system), GetConfigDef(#system, "package", ""))⟩
+      †⟨PackageDeclaration(GetModuleURLAndBase(#module), GetSystemURL(#system), GetConfigDef(#system, "package", ""))⟩
 
       import java.util.function.Function;
 
@@ -67,7 +67,7 @@ func ToJavaAux(#system: TSystem, #module: Module, #source: String) -> Result
     ()->Success((#source,)))
 
 /* Tell whether the generated files needed to be regenerated */
-func JavaNeedRegen(#system:TSystem, #url: String) -> Bool
+func JavaNeedRegen(#system:TSystem, #url_and_base: URLAndBase) -> Bool
 → TRUE
 
 // --- Translate module
@@ -1582,8 +1582,13 @@ func RegisterDataForm(String, String, Core_cform_sort) -> Text4_text_sort
        context.registerVarMaker(†⟨Text-QuoteEscape(#sortname)⟩, ⟨STRING:#classname⟩::var⟨STRING: Mangle(#sortname)⟩);⟧
 
 /* Print package declaration */
-func PackageDeclaration(#url: String, #mainurl: String, #package: String) -> Text4_text_sort
-→ PackageDeclaration2(#package, Replace(RelativePath(#url, #mainurl), "/", "."))
+func PackageDeclaration(#url_and_base: URLAndBase, #mainurl: String, #package: String) -> Text4_text_sort
+rule PackageDeclaration(URLAndBase(#url,#base): URLAndBase, #mainurl: String, #package: String)
+→ let #relative_path = if (StringEqual(#base, ""))
+                         RelativePath(#url, #mainurl)
+                       else
+                         RelativePath(#url, ConcatString(#base, "/."))
+  PackageDeclaration2(#package, Replace(#relative_path, "/", "."))
 
 func PackageDeclaration2(#base: String, #sub: String) -> Text4_text_sort
 → PackageDeclaration3(#base, If(StringEqual(Trim(#base), ""), ()->"", ()->"."), #sub)
@@ -1616,7 +1621,7 @@ func ClassName(#name: String) -> String
 → Mangle(UpCaseFirst(AfterLast(BeforeLast(#name, "."), "/")))
 
 /* Get the absolute name of the target java file */
-@Extern func TargetJavaFilename(#input: String, #dest: String, #mainurl:String, #package: String) -> String
+@Extern func TargetJavaFilename(#input: String, #base: String, #dest: String, #mainurl:String, #package: String) -> String
 
 /* Get sub directory of `#module` relative to `#mainmodule` */
 @Extern func RelativePath(#input: String, #mainurl:String) -> String

--- a/src/cg/java/cgjava.tsc
+++ b/src/cg/java/cgjava.tsc
@@ -67,7 +67,7 @@ func ToJavaAux(#system: TSystem, #module: Module, #source: String) -> Result
     ()->Success((#source,)))
 
 /* Tell whether the generated files needed to be regenerated */
-func JavaNeedRegen(#system:TSystem, #url_and_base: URLAndBase) -> Bool
+func JavaNeedRegen(#system:TSystem, #module_url: URLAndBase) -> Bool
 → TRUE
 
 // --- Translate module
@@ -1103,7 +1103,7 @@ func ResolveTypeParamCons(Option<Core_csort_sort>) -> Text4_text_sort
 
   rule ResolveTypeParamCons(SOME(#))
   → text⟦⟧
-  
+
 
 /* Get sub sort. Get it from term and if not available on sort */
 func SubSort({String : JEnvEntry}, Core_cterm_sort, Option<List<Core_csort_sort>>) -> Option<Core_csort_sort>
@@ -1582,9 +1582,11 @@ func RegisterDataForm(String, String, Core_cform_sort) -> Text4_text_sort
        context.registerVarMaker(†⟨Text-QuoteEscape(#sortname)⟩, ⟨STRING:#classname⟩::var⟨STRING: Mangle(#sortname)⟩);⟧
 
 /* Print package declaration */
-func PackageDeclaration(#url_and_base: URLAndBase, #mainurl: String, #package: String) -> Text4_text_sort
-rule PackageDeclaration(URLAndBase(#url,#base): URLAndBase, #mainurl: String, #package: String)
-→ let #relative_path = if (StringEqual(#base, ""))
+func PackageDeclaration(#module_url: URLAndBase, #mainurl: String, #package: String) -> Text4_text_sort
+rule PackageDeclaration(#module_url: URLAndBase, #mainurl: String, #package: String)
+→ let #url = GetURLOfUnB(#module_url)
+  let #base = GetBaseOfUnB(#module_url)
+  let #relative_path = if (StringEqual(#base, ""))
                          RelativePath(#url, #mainurl)
                        else
                          RelativePath(#url, ConcatString(#base, "/."))

--- a/src/infer/infer.tsc
+++ b/src/infer/infer.tsc
@@ -33,8 +33,8 @@ func InferM(#system: TSystem, #module: Module) -> Module
     ( ) -> #module)
 
 func InferM2(TSystem, Module) -> Module
-rule InferM2(#system,  Module(#url, #content, #compiled))
-→ Debug(ConcatString("Type check ", #url), ()->Module(#url, InferContent(#system, #content), #compiled))
+rule InferM2(#system,  Module(#url_and_base, #content, #compiled))
+→ Debug(ConcatString("Type check ", GetURLOfUnB(#url_and_base)), ()->Module(#url_and_base, InferContent(#system, #content), #compiled))
 
 // -- Content
 

--- a/src/std/language.tsc
+++ b/src/std/language.tsc
@@ -52,3 +52,7 @@ func SaveTerm<a b>(#filename: String, #term: a, #result: b) -> b
 /* Delete file at given location
    @return TRUE if succeeded, FALSE otherwise */
 @Extern func FileDelete(#url: String) -> Bool
+
+/* Check whether file exists
+   @return TRUE if file exists, FALSE otherwise */
+@Extern func FileExists(#url: String) -> Bool

--- a/src/systemdef.tsc
+++ b/src/systemdef.tsc
@@ -31,17 +31,23 @@ enum TSystem | TSystem(String /* Initial url */, {String /* url */ : Module}, {S
 func InitSystem(#url: String, #config: {String:String}) -> TSystem
 → TSystem(#url, MapNew, #config)
 
-/* Module's URL and the base URL against which it was found */
-enum URLAndBase | URLAndBase(String /* URL */, String /* base URL */)
+/* Module's base URL and the relative URL for where it is found.
+  The full URL is ConcatString(baseURL, "/", relativeURL)
+  If the baseURL is empty "", then the URL is the relativeURL */
+enum URLAndBase | URLAndBase(String /* base URL */, String /* relative URL */)
 
 func GetURLOfUnB(URLAndBase) -> String
-rule GetURLOfUnB(URLAndBase(#url,#base)) → #url
+rule GetURLOfUnB(URLAndBase(#base,#rel))
+ → if StringEqual(#base, "") #rel else ConcatString(#base, "/", #rel)
 
 func GetBaseOfUnB(URLAndBase) -> String
-rule GetBaseOfUnB(URLAndBase(#url,#base)) → #base
+rule GetBaseOfUnB(URLAndBase(#base,#rel)) → #base
+
+func GetRelativeOfUnB(URLAndBase) -> String
+rule GetRelativeOfUnB(URLAndBase(#base,#rel)) → #rel
 
 /* A Tosca module  */
-enum Module | Module(URLAndBase /* filename+base */, Content /* of module */, Bool /* Compiled? */)
+enum Module | Module(URLAndBase /* base+filename */, Content /* of module */, Bool /* Compiled? */)
 
 // --- module representation
 
@@ -90,13 +96,13 @@ func HasModule(#system: TSystem, #url: String) -> Bool
   @return An existing module or a new one.
  */
 func LookupOrCreateModule(#system: TSystem, #url: String /* url */) -> Module
-→ IfPresent(LookupModule(#system, #url), (mod)->mod, ()->Module(URLAndBase(#url,""), Content((), {}, {}, {}, {}, {}), FALSE))
+→ IfPresent(LookupModule(#system, #url), (mod)->mod, ()->Module(URLAndBase("", #url), Content((), {}, {}, {}, {}, {}), FALSE))
 
 /* Gets module for given url.
   @return An existing module or a new one.
  */
 func ExtractOrCreateModule(#system: TSystem, #url: String /* url */) -> PPair<TSystem Module>
-→ IfPresent(LookupModule(#system, #url), (mod)->PairCons(RemoveModule(#system, #url), mod), ()->PairCons(#system, Module(URLAndBase(#url,""), Content((), {}, {}, {}, {}, {}), FALSE)))
+→ IfPresent(LookupModule(#system, #url), (mod)->PairCons(RemoveModule(#system, #url), mod), ()->PairCons(#system, Module(URLAndBase("", #url), Content((), {}, {}, {}, {}, {}), FALSE)))
 
 /* Get import declarations for the module at given `#url` */
 func GetImportsS(#system: TSystem, #url: String) -> List<Core_cqidentifier_sort>
@@ -174,15 +180,15 @@ func PutAliasS(#system: TSystem, #url: String, #alias: Core_cdecl_sort) -> TSyst
 
 /* Gets module URL */
 func GetModuleURL(Module) -> String
-rule GetModuleURL(Module(URLAndBase(#url,#base), #content, #compiled)) → #url
+rule GetModuleURL(Module(#module_url, #content, #compiled)) → GetURLOfUnB(#module_url)
 
 /* Gets module URL */
 func GetModuleURLBase(Module) -> String
-rule GetModuleURLBase(Module(URLAndBase(#url,#base), #content, #compiled)) → #base
+rule GetModuleURLBase(Module(#module_url, #content, #compiled)) → GetBaseOfUnB(#module_url)
 
 /* Gets module URL and Base */
 func GetModuleURLAndBase(Module) -> URLAndBase
-rule GetModuleURLAndBase(Module(#url_and_base, #content, #compiled)) → #url_and_base
+rule GetModuleURLAndBase(Module(#module_url, #content, #compiled)) → #module_url
 
 /* Gets module content */
 func GetModuleContent(Module) -> Content
@@ -468,9 +474,9 @@ func IfConfigDef<a>(#system: TSystem, #key: String, #true: (String)->a, #false: 
    @param `#core` core program
    @return loaded core program into internal representation
  */
-func LoadCore(#system: TSystem, #url_and_base: URLAndBase, #core: Core_ccrsx_sort, #compiled: Bool) -> TSystem
-→ let #url = GetURLOfUnB(#url_and_base)
-  LoadCoreS(If(HasModule(#system, #url), ()->#system, ()->PutModule(#system, #url, Module(#url_and_base, Content((), {}, {}, {}, {}, {}), #compiled))),
+func LoadCore(#system: TSystem, #module_url: URLAndBase, #core: Core_ccrsx_sort, #compiled: Bool) -> TSystem
+→ let #url = GetURLOfUnB(#module_url)
+  LoadCoreS(If(HasModule(#system, #url), ()->#system, ()->PutModule(#system, #url, Module(#module_url, Content((), {}, {}, {}, {}, {}), #compiled))),
               #url, #core)
 
 func LoadCoreS(TSystem, String, Core_ccrsx_sort) -> TSystem
@@ -524,10 +530,10 @@ func ResolveImport(#system: TSystem, #url:String, #import: Core_cqidentifier_sor
 → ResolveImportAux(#system, #url, QIdentifierList(#import, FALSE))
 
 func ResolveImportAux(#system: TSystem, #url:String, #name: List<String>) -> URLAndBase
-→ let #tail = ConcatString("/", ConcatString(Join(#name, "/"), ".tsc"))
+→ let #tail = ConcatString(Join(#name, "/"), ".tsc")
   let #baseStd = GetConfigDef(#system, "baseStd", "")
   if IsStandardPrefix(Head(#name))
-    URLAndBase(ConcatString(#baseStd, #tail), #baseStd)
+    URLAndBase(#baseStd, #tail)
   else
     IfConfigDef(#system, "import-dir",
         (paths)->CheckImportPaths(#system, Split(paths, " "), #tail),
@@ -537,9 +543,10 @@ func ResolveImportAux(#system: TSystem, #url:String, #name: List<String>) -> URL
 func CheckImportPaths(#system: TSystem, #import-paths: List<String>, #tail: String) -> URLAndBase
 
   rule CheckImportPaths(#system, (#path, #other_paths...), #tail)
-   → let #check-path = ConcatString(#path, #tail)
+   → let #module_url = URLAndBase(#path, #tail)
+     let #check-path = GetURLOfUnB(#module_url)
      if FileExists(#check-path)
-       URLAndBase(#check-path, #path)
+       #module_url
      else
        CheckImportPaths(#system, #other_paths, #tail)
 
@@ -548,7 +555,7 @@ func CheckImportPaths(#system: TSystem, #import-paths: List<String>, #tail: Stri
 
 func ResolveDefaultImportPath(#system: TSystem, #tail: String) -> URLAndBase
 → let #base = PathJoin(PathParent(Path(GetSystemURL(#system))))
-  URLAndBase(ConcatString(#base, #tail), #base)
+  URLAndBase(#base, #tail)
 
 /* @return `TRUE` if the given `#import` is a standard library module */
 func IsStandardImport(#system: TSystem, #import: Core_cqidentifier_sort) -> Bool

--- a/src/systemdef.tsc
+++ b/src/systemdef.tsc
@@ -31,8 +31,17 @@ enum TSystem | TSystem(String /* Initial url */, {String /* url */ : Module}, {S
 func InitSystem(#url: String, #config: {String:String}) -> TSystem
 → TSystem(#url, MapNew, #config)
 
+/* Module's URL and the base URL against which it was found */
+enum URLAndBase | URLAndBase(String /* URL */, String /* base URL */)
+
+func GetURLOfUnB(URLAndBase) -> String
+rule GetURLOfUnB(URLAndBase(#url,#base)) → #url
+
+func GetBaseOfUnB(URLAndBase) -> String
+rule GetBaseOfUnB(URLAndBase(#url,#base)) → #base
+
 /* A Tosca module  */
-enum Module | Module(String /* filename */, Content /* of module */, Bool /* Compiled? */)
+enum Module | Module(URLAndBase /* filename+base */, Content /* of module */, Bool /* Compiled? */)
 
 // --- module representation
 
@@ -81,13 +90,13 @@ func HasModule(#system: TSystem, #url: String) -> Bool
   @return An existing module or a new one.
  */
 func LookupOrCreateModule(#system: TSystem, #url: String /* url */) -> Module
-→ IfPresent(LookupModule(#system, #url), (mod)->mod, ()->Module(#url, Content((), {}, {}, {}, {}, {}), FALSE))
+→ IfPresent(LookupModule(#system, #url), (mod)->mod, ()->Module(URLAndBase(#url,""), Content((), {}, {}, {}, {}, {}), FALSE))
 
 /* Gets module for given url.
   @return An existing module or a new one.
  */
 func ExtractOrCreateModule(#system: TSystem, #url: String /* url */) -> PPair<TSystem Module>
-→ IfPresent(LookupModule(#system, #url), (mod)->PairCons(RemoveModule(#system, #url), mod), ()->PairCons(#system, Module(#url, Content((), {}, {}, {}, {}, {}), FALSE)))
+→ IfPresent(LookupModule(#system, #url), (mod)->PairCons(RemoveModule(#system, #url), mod), ()->PairCons(#system, Module(URLAndBase(#url,""), Content((), {}, {}, {}, {}, {}), FALSE)))
 
 /* Get import declarations for the module at given `#url` */
 func GetImportsS(#system: TSystem, #url: String) -> List<Core_cqidentifier_sort>
@@ -165,7 +174,15 @@ func PutAliasS(#system: TSystem, #url: String, #alias: Core_cdecl_sort) -> TSyst
 
 /* Gets module URL */
 func GetModuleURL(Module) -> String
-rule GetModuleURL(Module(#url, #content, #compiled)) → #url
+rule GetModuleURL(Module(URLAndBase(#url,#base), #content, #compiled)) → #url
+
+/* Gets module URL */
+func GetModuleURLBase(Module) -> String
+rule GetModuleURLBase(Module(URLAndBase(#url,#base), #content, #compiled)) → #base
+
+/* Gets module URL and Base */
+func GetModuleURLAndBase(Module) -> URLAndBase
+rule GetModuleURLAndBase(Module(#url_and_base, #content, #compiled)) → #url_and_base
 
 /* Gets module content */
 func GetModuleContent(Module) -> Content
@@ -451,8 +468,9 @@ func IfConfigDef<a>(#system: TSystem, #key: String, #true: (String)->a, #false: 
    @param `#core` core program
    @return loaded core program into internal representation
  */
-func LoadCore(#system: TSystem, #url: String, #core: Core_ccrsx_sort, #compiled: Bool) -> TSystem
-→ LoadCoreS(If(HasModule(#system, #url), ()->#system, ()->PutModule(#system, #url, Module(#url, Content((), {}, {}, {}, {}, {}), #compiled))),
+func LoadCore(#system: TSystem, #url_and_base: URLAndBase, #core: Core_ccrsx_sort, #compiled: Bool) -> TSystem
+→ let #url = GetURLOfUnB(#url_and_base)
+  LoadCoreS(If(HasModule(#system, #url), ()->#system, ()->PutModule(#system, #url, Module(#url_and_base, Content((), {}, {}, {}, {}, {}), #compiled))),
               #url, #core)
 
 func LoadCoreS(TSystem, String, Core_ccrsx_sort) -> TSystem
@@ -473,7 +491,7 @@ func LoadDeclsS(TSystem, String, List<Core_cdecl_sort>, Bool) -> TSystem
   // Extend existing data sort declaration
   rule LoadDeclsS(#system, #url, cdecl+⟦ ##canno* data ##csortvars? ##cidentifierqualifier* ##CONSTRUCTOR ##cforms ##cdecl+ ⟧, #extends)
   → LoadDeclsS(
-       LoadDeclsS(#system, ResolveImportAux(#system, #url, IdentifierQList(#cidentifierqualifier*, FALSE)), cdecl+⟦ ##canno* data ##csortvars? ##CONSTRUCTOR ##cforms ⟧, TRUE),
+       LoadDeclsS(#system, GetURLOfUnB(ResolveImportAux(#system, #url, IdentifierQList(#cidentifierqualifier*, FALSE))), cdecl+⟦ ##canno* data ##csortvars? ##CONSTRUCTOR ##cforms ⟧, TRUE),
        #url, #cdecl+, #extends)
 
   // Sort alias declaration
@@ -502,13 +520,35 @@ func HasNativeImpl(#system: TSystem, #name:String) -> Bool
 // ---- Import function helpers
 
 /* Convert Tosca module into an url */
-func ResolveImport(#system: TSystem, #url:String, #import: Core_cqidentifier_sort) -> String
+func ResolveImport(#system: TSystem, #url:String, #import: Core_cqidentifier_sort) -> URLAndBase
 → ResolveImportAux(#system, #url, QIdentifierList(#import, FALSE))
 
-func ResolveImportAux(#system: TSystem, #url:String, #name: List<String>) -> String
-→ ConcatString(If(IsStandardPrefix(Head(#name)), ()->GetConfigDef(#system, "baseStd", ""), ()->PathJoin(PathParent(Path(GetSystemURL(#system))))),
-   ConcatString("/",
-   ConcatString(Join(#name, "/"), ".tsc")))
+func ResolveImportAux(#system: TSystem, #url:String, #name: List<String>) -> URLAndBase
+→ let #tail = ConcatString("/", ConcatString(Join(#name, "/"), ".tsc"))
+  let #baseStd = GetConfigDef(#system, "baseStd", "")
+  if IsStandardPrefix(Head(#name))
+    URLAndBase(ConcatString(#baseStd, #tail), #baseStd)
+  else
+    IfConfigDef(#system, "import-dir",
+        (paths)->CheckImportPaths(#system, Split(paths, " "), #tail),
+        ()->ResolveDefaultImportPath(#system, #tail))
+
+/* Search import paths for Tosca module */
+func CheckImportPaths(#system: TSystem, #import-paths: List<String>, #tail: String) -> URLAndBase
+
+  rule CheckImportPaths(#system, (#path, #other_paths...), #tail)
+   → let #check-path = ConcatString(#path, #tail)
+     if FileExists(#check-path)
+       URLAndBase(#check-path, #path)
+     else
+       CheckImportPaths(#system, #other_paths, #tail)
+
+  rule CheckImportPaths(#system, (), #tail)
+   → ResolveDefaultImportPath(#system, #tail)
+
+func ResolveDefaultImportPath(#system: TSystem, #tail: String) -> URLAndBase
+→ let #base = PathJoin(PathParent(Path(GetSystemURL(#system))))
+  URLAndBase(ConcatString(#base, #tail), #base)
 
 /* @return `TRUE` if the given `#import` is a standard library module */
 func IsStandardImport(#system: TSystem, #import: Core_cqidentifier_sort) -> Bool

--- a/src/tosca.tsc
+++ b/src/tosca.tsc
@@ -40,7 +40,7 @@ import pg::genparser
  */
 func Compile(#url: String, #config: {String:String}) -> Result
 = let #system = InitSystem(#url, #config)
-  let #loaded = LoadModuleS(#system, URLAndBase(#url,""), FALSE)
+  let #loaded = LoadModuleS(#system, URLAndBase("", #url), FALSE)
   CompileS(NoAnnoS(#loaded))
 
 // --- Compilation
@@ -79,8 +79,8 @@ func LoadImport(#system: TSystem, #url:String, #import: Core_cqidentifier_sort) 
 = LoadModuleS(#system, ResolveImport(#system, #url, #import), IsStandardImport(#system, #import))
 
 /* Load module content and update system */
-func LoadModuleS(#system: TSystem, #url_and_base: URLAndBase, #standard:Bool) -> TSystem
-= let #url = GetURLOfUnB(#url_and_base)
+func LoadModuleS(#system: TSystem, #module_url: URLAndBase, #standard:Bool) -> TSystem
+= let #url = GetURLOfUnB(#module_url)
   if HasModule(#system, #url)
      #system
   else
@@ -88,18 +88,18 @@ func LoadModuleS(#system: TSystem, #url_and_base: URLAndBase, #standard:Bool) ->
                   ParseResource("ccrsx", #url)
                 else
                   ToCore(#url, ParseResource("transscript", Debug(#url, ()->#url)))
-    LoadModuleAux(LoadCore(#system, #url_and_base, #core, Or(#standard, Not(NeedRegen(#system, #url_and_base, #standard)))), #url)
+    LoadModuleAux(LoadCore(#system, #module_url, #core, Or(#standard, Not(NeedRegen(#system, #module_url, #standard)))), #url)
 
 func LoadModuleAux(#system: TSystem, #url: String) -> TSystem
 = LoadImportedModules(#system, #url, GetImportsS(#system, #url))
 
 // --- Determine whether module source file is newer than the corresponding generated files.
 
-func NeedRegen(#system: TSystem, #url_and_base: URLAndBase, #standard: Bool) -> Bool
+func NeedRegen(#system: TSystem, #module_url: URLAndBase, #standard: Bool) -> Bool
 → if #standard
     FALSE
   else if HasOption(GetConfig(#system, "inc"))
-    IfConfigDef(#system, "cpp", (v)->CppNeedRegen(#system, #url_and_base), ()->JavaNeedRegen(#system, #url_and_base))
+    IfConfigDef(#system, "cpp", (v)->CppNeedRegen(#system, #module_url), ()->JavaNeedRegen(#system, #module_url))
   else
     TRUE
 

--- a/src/tosca.tsc
+++ b/src/tosca.tsc
@@ -40,7 +40,7 @@ import pg::genparser
  */
 func Compile(#url: String, #config: {String:String}) -> Result
 = let #system = InitSystem(#url, #config)
-  let #loaded = LoadModuleS(#system, #url, FALSE)
+  let #loaded = LoadModuleS(#system, URLAndBase(#url,""), FALSE)
   CompileS(NoAnnoS(#loaded))
 
 // --- Compilation
@@ -79,26 +79,27 @@ func LoadImport(#system: TSystem, #url:String, #import: Core_cqidentifier_sort) 
 = LoadModuleS(#system, ResolveImport(#system, #url, #import), IsStandardImport(#system, #import))
 
 /* Load module content and update system */
-func LoadModuleS(#system: TSystem, #url: String, #standard:Bool) -> TSystem
-= if HasModule(#system, #url)
+func LoadModuleS(#system: TSystem, #url_and_base: URLAndBase, #standard:Bool) -> TSystem
+= let #url = GetURLOfUnB(#url_and_base)
+  if HasModule(#system, #url)
      #system
   else
     let #core = if EndsWith(#url, ".tscc")
                   ParseResource("ccrsx", #url)
                 else
                   ToCore(#url, ParseResource("transscript", Debug(#url, ()->#url)))
-    LoadModuleAux(LoadCore(#system, #url, #core, Or(#standard, Not(NeedRegen(#system, #url, #standard)))), #url)
+    LoadModuleAux(LoadCore(#system, #url_and_base, #core, Or(#standard, Not(NeedRegen(#system, #url_and_base, #standard)))), #url)
 
 func LoadModuleAux(#system: TSystem, #url: String) -> TSystem
 = LoadImportedModules(#system, #url, GetImportsS(#system, #url))
 
 // --- Determine whether module source file is newer than the corresponding generated files.
 
-func NeedRegen(#system: TSystem, #url: String, #standard: Bool) -> Bool
+func NeedRegen(#system: TSystem, #url_and_base: URLAndBase, #standard: Bool) -> Bool
 → if #standard
     FALSE
   else if HasOption(GetConfig(#system, "inc"))
-    IfConfigDef(#system, "cpp", (v)->CppNeedRegen(#system, #url), ()->JavaNeedRegen(#system, #url))
+    IfConfigDef(#system, "cpp", (v)->CppNeedRegen(#system, #url_and_base), ()->JavaNeedRegen(#system, #url_and_base))
   else
     TRUE
 

--- a/targets/cpp/std/src/std/string-extern.cpp
+++ b/targets/cpp/std/src/std/string-extern.cpp
@@ -5,6 +5,7 @@
 #include "std/core.h"
 #include "std/listdef.h"
 #include "strutils.h"
+#include <memory.h>
 #include <regex>
 
 using namespace tosca;
@@ -27,10 +28,23 @@ StringTerm& BeforeFirst(Context& ctx, StringTerm& string, StringTerm& sep)
     const tosca::string& usep = sep.Unbox();
     tosca::string::size_type idx = ustring.find(usep);
 
-    StringTerm& result = newStringTerm(ctx, (idx == tosca::string::npos) ? ustring : ustring.substr(0, idx));
-    string.Release();
     sep.Release();
-    return result;
+
+    if (idx == tosca::string::npos)
+    {
+        return string;
+    }
+    else
+    {
+        char *c_ubefore = (char*) malloc(idx+1);
+        memcpy(c_ubefore, ustring.c_str(), idx);
+        c_ubefore[idx] = '\0';
+        StringTerm& result = newStringTerm(ctx, (const char *)c_ubefore);
+        free(c_ubefore);
+        string.Release();
+
+        return result;
+    }
 }
 
 Bool& StringEqual(Context& ctx, StringTerm& str1, StringTerm& str2)

--- a/targets/java/runtime/org/transscript/Tool.java
+++ b/targets/java/runtime/org/transscript/Tool.java
@@ -90,6 +90,8 @@ public class Tool {
 				"  class=<classname>         the name of the compiled Tosca program to run. Cannot be used with option rules");
 		System.out.println(
 				"  build-dir=<directory>     where to store the intermediate files. Default is current directory");
+		System.out.println(
+				"  import-dir=<directory>    where to find imported modules. Default is current directory. Can occur multiple times.");
 		// System.out.println(" base=<name> base source directory");
 		System.out.println("  javabasepackage=<name>    Java base package name of generated Java files");
 		System.out.println("  parsers=<classnames>      comma separated list of parsers classname");
@@ -287,6 +289,8 @@ public class Tool {
 
 		String dest = resolveBuildDir(rules, env.get("build-dir"));
 
+		String importPaths = env.get("import-dir");
+
 		String parsers = "org.transscript.core.CoreMetaParser,org.transscript.parser.TransScriptMetaParser,org.transscript.text.Text4MetaParser";
 		if (env.get("parsers") != null)
 			parsers += "," + env.get("parsers");
@@ -294,6 +298,11 @@ public class Tool {
 		Map<String, String> buildEnv = new HashMap<>(env);
 		Map<String, Object> internalEnv = new HashMap<>();
 		MapTerm<StringTerm, StringTerm> config = MapTerm.mapTerm();
+
+		if (importPaths != null)
+		{
+			config.putValue(stringTerm("import-dir"), stringTerm(importPaths));
+		}
 
 		config.putValue(stringTerm("build-dir"), stringTerm(dest));
 

--- a/targets/java/runtime/org/transscript/compiler/cg/cpp/CgcppExtern.java
+++ b/targets/java/runtime/org/transscript/compiler/cg/cpp/CgcppExtern.java
@@ -18,12 +18,13 @@ public class CgcppExtern
 {
 
 	/** Get the absolute name of the target c++ source file */
-	public static StringTerm TargetCppSource(Context context, StringTerm mainurl, StringTerm input, StringTerm buildir)
+	public static StringTerm TargetCppSource(Context context, StringTerm mainurl, StringTerm input, StringTerm base, StringTerm buildir)
 	{
 		StringTerm emainurl = force(context, mainurl);
 		StringTerm einput = force(context, input);
+		StringTerm ebase = force(context, base);
 		StringTerm ebuildir = force(context, buildir);
-		StringTerm r = stringTerm(Utils.targetCppFilename(einput.unbox(), ebuildir.unbox(), emainurl.unbox(), true, false));
+		StringTerm r = stringTerm(Utils.targetCppFilename(einput.unbox(), ebase.unbox(), ebuildir.unbox(), emainurl.unbox(), true, false));
 		emainurl.release();
 		einput.release();
 		ebuildir.release();
@@ -31,12 +32,13 @@ public class CgcppExtern
 	}
 
 	/** Get the absolute name of the target c++ header file */
-	public static StringTerm TargetCppHeader(Context context, StringTerm mainurl, StringTerm input, StringTerm buildir)
+	public static StringTerm TargetCppHeader(Context context, StringTerm mainurl, StringTerm input, StringTerm base, StringTerm buildir)
 	{
 		StringTerm emainurl = force(context, mainurl);
 		StringTerm einput = force(context, input);
+		StringTerm ebase = force(context, base);
 		StringTerm ebuildir = force(context, buildir);
-		StringTerm r = stringTerm(Utils.targetCppFilename(einput.unbox(), ebuildir.unbox(), emainurl.unbox(), true, true));
+		StringTerm r = stringTerm(Utils.targetCppFilename(einput.unbox(), ebase.unbox(), ebuildir.unbox(), emainurl.unbox(), true, true));
 		emainurl.release();
 		einput.release();
 		ebuildir.release();

--- a/targets/java/runtime/org/transscript/compiler/cg/java/CgjavaExtern.java
+++ b/targets/java/runtime/org/transscript/compiler/cg/java/CgjavaExtern.java
@@ -15,14 +15,15 @@ import org.transscript.tool.Utils;
 public class CgjavaExtern
 {
 
-	public static StringTerm TargetJavaFilename(Context context, StringTerm input, StringTerm buildir, StringTerm mainurl, StringTerm pkg)
+	public static StringTerm TargetJavaFilename(Context context, StringTerm input, StringTerm base, StringTerm buildir, StringTerm mainurl, StringTerm pkg)
 	{
 		StringTerm einput = Term.force(context, input);
+		StringTerm ebase = Term.force(context, base);
 		StringTerm ebuildir = Term.force(context, buildir);
 		StringTerm emainurl = Term.force(context, mainurl);
 		StringTerm epkg = Term.force(context, pkg);
 		StringTerm r = StringTerm.stringTerm(
-				Utils.targetJavaFilename(einput.unbox(), ebuildir.unbox(), emainurl.unbox(), epkg.unbox(), true));
+				Utils.targetJavaFilename(einput.unbox(), ebase.unbox(), ebuildir.unbox(), emainurl.unbox(), epkg.unbox(), true));
 		einput.release();
 		ebuildir.release();
 		emainurl.release();

--- a/targets/java/runtime/org/transscript/compiler/std/LanguageExtern.java
+++ b/targets/java/runtime/org/transscript/compiler/std/LanguageExtern.java
@@ -229,4 +229,10 @@ public class LanguageExtern {
 		return result;
 	}
 
+	public static Bool FileExists(Context context, StringTerm filename) {
+		File file = new File(filename.unbox());
+		Bool result = file.exists() ? Core.TRUE(context) : Core.FALSE(context);
+		filename.release();
+		return result;
+	}
 }

--- a/targets/java/runtime/org/transscript/tool/Utils.java
+++ b/targets/java/runtime/org/transscript/tool/Utils.java
@@ -303,13 +303,14 @@ public class Utils
 	 * @param pkg
 	 * @param makeDirs whether to make destination directories.
 	 */
-	public static String targetJavaFilename(String input, String dest, String mainurl, String pkg, boolean makeDirs)
+	public static String targetJavaFilename(String input, String base, String dest, String mainurl, String pkg, boolean makeDirs)
 	{
 		// Offset destination considering package and subpackage
 		if (pkg != null)
 			dest += File.separator + pkg.replace('.', File.separatorChar);
 
-		String subdir = relativePath(input, mainurl);
+		String subdir = base.equals("") ? relativePath(input, mainurl)
+                                                : relativePath(input, base+File.separatorChar+".");
 		dest = subdir.trim().equals("") ? dest : dest + File.separator + subdir;
 
 		if (makeDirs)
@@ -329,16 +330,18 @@ public class Utils
 	/**
 	 * Get the absolute name of the target cpp file
 	 * @param input Tosca file
+	 * @param input Base directory against which Tosca file name was resolved to be produced (if any)
 	 * @param dest target directory
 	 * @param mainurl TODO
 	 * @param makeDirs whether to make destination directories.
 	 * @param header whether to get the header target file name.
 	 */
-	public static String targetCppFilename(String input, String dest, String mainurl, boolean makeDirs, boolean header)
+	public static String targetCppFilename(String input, String base, String dest, String mainurl, boolean makeDirs, boolean header)
 	{
 		dest += File.separator + "src";
 
-		String subdir = relativePath(input, mainurl);
+		String subdir = base.equals("") ? relativePath(input, mainurl)
+						: relativePath(input, base+File.separator+".");
 		dest = subdir.trim().equals("") ? dest : dest + File.separator + subdir;
 
 		if (makeDirs)


### PR DESCRIPTION
Add command line argument `import-dir`.
Multiple import directories may be added.
They will be searched for `import` statements in Tosca prior to the main module directory being searched.